### PR TITLE
Support per-server config

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,5 +7,10 @@ Dubai Brethren Discord bot. This is a joke project.
 - `uptime`: Get the bot uptime and start time.
 - `avatar [user]`: Show the specified user's avatar. If left empty, will show your avatar.
 
+## Server Configuration
+- `setlogchannel [channel]`: Set the channel the bot should use for logging deleted messages.
+- `ignorechannel [channel]`: Toggle whether a channel should be ignored by the logger.
+- `ignoredchannels`: List ignored channels for this server.
+
 ## Fun
 TBD

--- a/bot.py
+++ b/bot.py
@@ -18,7 +18,8 @@ extensions = [
     'cogs.fun',
     # 'cogs.fun2',
     'cogs.logger',
-    'cogs.math'
+    'cogs.math',
+    'cogs.server_config'
 ]
 
 

--- a/cogs/logger.py
+++ b/cogs/logger.py
@@ -15,8 +15,15 @@ class Logger(commands.Cog):
     
     @commands.Cog.listener()
     async def on_message_delete(self, message: discord.Message):
-        # Only messages deleted in the specified guild should be logged
-        if message.guild is None or message.guild.id != self.bot.config.log_guild_id:
+        if message.guild is None:
+            return
+
+        guild_cfg = definitions.get_guild_config(message.guild.id)
+
+        if guild_cfg.log_channel_id is None:
+            return
+
+        if message.channel.id in guild_cfg.ignored_channels:
             return
         
         # Store deleted message for sniping
@@ -30,7 +37,7 @@ class Logger(commands.Cog):
             message.author.id,
             message.content
         )
-        log_channel = message.guild.get_channel(self.bot.config.log_channel_id)
+        log_channel = message.guild.get_channel(guild_cfg.log_channel_id)
         if log_channel:
             embed = discord.Embed(
                 title="Message Deleted",

--- a/cogs/server_config.py
+++ b/cogs/server_config.py
@@ -1,0 +1,42 @@
+import discord
+from discord.ext import commands
+import definitions
+
+class ServerConfig(commands.Cog):
+    """Commands to configure guild specific settings."""
+
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+
+    @commands.hybrid_command(name="setlogchannel", help="Set the log channel for this server.")
+    @commands.has_guild_permissions(manage_guild=True)
+    async def set_log_channel(self, ctx: commands.Context, channel: discord.TextChannel):
+        cfg = definitions.get_guild_config(ctx.guild.id)
+        cfg.log_channel_id = channel.id
+        definitions.save_config()
+        await ctx.reply(f"Log channel set to {channel.mention}")
+
+    @commands.hybrid_command(name="ignorechannel", help="Toggle logging for a channel.")
+    @commands.has_guild_permissions(manage_guild=True)
+    async def ignore_channel(self, ctx: commands.Context, channel: discord.TextChannel):
+        cfg = definitions.get_guild_config(ctx.guild.id)
+        if channel.id in cfg.ignored_channels:
+            cfg.ignored_channels.remove(channel.id)
+            action = "removed from"
+        else:
+            cfg.ignored_channels.append(channel.id)
+            action = "added to"
+        definitions.save_config()
+        await ctx.reply(f"{channel.mention} {action} the ignore list")
+
+    @commands.hybrid_command(name="ignoredchannels", help="List channels ignored by the logger.")
+    async def list_ignored(self, ctx: commands.Context):
+        cfg = definitions.get_guild_config(ctx.guild.id)
+        if not cfg.ignored_channels:
+            await ctx.reply("No ignored channels.")
+            return
+        channels = [f"<#{cid}>" for cid in cfg.ignored_channels]
+        await ctx.reply("Ignored channels: " + ", ".join(channels))
+
+async def setup(bot):
+    await bot.add_cog(ServerConfig(bot))

--- a/config.json
+++ b/config.json
@@ -1,6 +1,10 @@
 {
     "command_prefix": ";",
     "owner_id": 424970840015110145,
-    "log_channel_id": 1161644728840888341,
-    "log_guild_id": 1158077169348661330
+    "guilds": {
+        "1158077169348661330": {
+            "log_channel_id": 1161644728840888341,
+            "ignored_channels": []
+        }
+    }
 }

--- a/definitions.py
+++ b/definitions.py
@@ -5,25 +5,72 @@ from discord.ext import commands
 logger = logging.getLogger(__name__)
 
 
+class GuildConfig:
+    """Configuration specific to a Discord guild."""
+
+    def __init__(self, data: dict | None = None):
+        self.log_channel_id: int | None = None
+        self.ignored_channels: list[int] = []
+
+        if data:
+            self.log_channel_id = data.get('log_channel_id')
+            self.ignored_channels = data.get('ignored_channels', [])
+
+    def to_dict(self) -> dict:
+        return {
+            'log_channel_id': self.log_channel_id,
+            'ignored_channels': self.ignored_channels,
+        }
+
+
 class Config:
-    def __init__(self, data):
-        self.command_prefix = data.get('command_prefix', ';') # Default value: ";"
-        self.owner_id = data.get('owner_id', 424970840015110145) # Default owner: adam.2006
-        self.log_channel_id = data['log_channel_id'] # Channel to send logs (such as notification about editing/deletion) to
-        self.log_guild_id = data['log_guild_id'] # The guild to log 
+    def __init__(self, data: dict):
+        self.command_prefix = data.get('command_prefix', ';')
+        self.owner_id = data.get('owner_id', 424970840015110145)
+
+        self.guilds: dict[int, GuildConfig] = {
+            int(gid): GuildConfig(gcfg) for gid, gcfg in data.get('guilds', {}).items()
+        }
+
+    def to_dict(self) -> dict:
+        return {
+            'command_prefix': self.command_prefix,
+            'owner_id': self.owner_id,
+            'guilds': {str(gid): cfg.to_dict() for gid, cfg in self.guilds.items()},
+        }
+
+    def save(self, path: str = 'config.json') -> None:
+        with open(path, 'w') as file:  # pylint: disable=unspecified-encoding
+            json.dump(self.to_dict(), file, indent=4)
 
 
 def load_config(path='config.json') -> Config:
-    """Return the bot's configuration."""
-    with open(path, 'r') as file: # pylint: disable=unspecified-encoding
+    """Return the bot's configuration from ``path``."""
+    with open(path, 'r') as file:  # pylint: disable=unspecified-encoding
         data = json.load(file)
 
-    logger.debug(f"Loaded config: {data}")
+    logger.debug("Loaded config: %s", data)
     print(f"Loaded config: {data}")
     return Config(data=data)
 
 
 _config = load_config()
+
+def get_guild_config(guild_id: int) -> GuildConfig:
+    """Return the :class:`GuildConfig` for ``guild_id``.
+
+    If a configuration entry does not exist yet for the guild it will be
+    created and stored in memory (and will be written to disk on the next
+    :func:`save_config` call).
+    """
+    if guild_id not in _config.guilds:
+        _config.guilds[guild_id] = GuildConfig()
+    return _config.guilds[guild_id]
+
+
+def save_config(path: str = 'config.json') -> None:
+    """Persist the current configuration to ``path``."""
+    _config.save(path)
 
 def is_bot_owner():
     """Check whether command issuer is me (adam.2006)"""


### PR DESCRIPTION
## Summary
- add per-server config data structures
- log each guild with its own configuration
- allow admins to set log channel and ignored channels
- update bot extensions and documentation

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'PY'
import definitions
cfg = definitions.load_config()
PY` *(fails: ModuleNotFoundError: No module named 'discord')*

------
https://chatgpt.com/codex/tasks/task_b_68608f928838832193e3518e1f56fbd6