### PR TITLE
Fix snipe image embeds and reply jump buttons

### DIFF
--- a/database.py
+++ b/database.py
@@ -25,7 +25,9 @@ class Database:
                 created_at REAL,
                 attachments TEXT,
                 reply_author TEXT,
-                reply_content TEXT
+                reply_content TEXT,
+                reply_channel_id TEXT,
+                reply_message_id TEXT
             );
         """)
         await self.conn.execute("""
@@ -40,9 +42,23 @@ class Database:
                 edited_at REAL,
                 attachments TEXT,
                 reply_author TEXT,
-                reply_content TEXT
+                reply_content TEXT,
+                reply_channel_id TEXT,
+                reply_message_id TEXT
             );
         """)
+        await self.conn.commit()
+
+        # Attempt to add new columns for reply jump information if they don't exist
+        for table in ("snipes", "edit_snipes"):
+            try:
+                await self.conn.execute(f"ALTER TABLE {table} ADD COLUMN reply_channel_id TEXT")
+            except aiosqlite.OperationalError:
+                pass
+            try:
+                await self.conn.execute(f"ALTER TABLE {table} ADD COLUMN reply_message_id TEXT")
+            except aiosqlite.OperationalError:
+                pass
         await self.conn.commit()
 
     async def close(self):
@@ -81,13 +97,16 @@ class Database:
         attachments: str,
         reply_author: str | None,
         reply_content: str | None,
+        reply_channel_id: str | None,
+        reply_message_id: str | None,
     ):
         await self.conn.execute(
             """
             INSERT INTO snipes (
                 channel_id, message_id, author_id, author_name,
-                content, created_at, attachments, reply_author, reply_content
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                content, created_at, attachments, reply_author,
+                reply_content, reply_channel_id, reply_message_id
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(channel_id) DO UPDATE SET
                 message_id=excluded.message_id,
                 author_id=excluded.author_id,
@@ -96,7 +115,9 @@ class Database:
                 created_at=excluded.created_at,
                 attachments=excluded.attachments,
                 reply_author=excluded.reply_author,
-                reply_content=excluded.reply_content;
+                reply_content=excluded.reply_content,
+                reply_channel_id=excluded.reply_channel_id,
+                reply_message_id=excluded.reply_message_id;
             """,
             (
                 channel_id,
@@ -108,6 +129,8 @@ class Database:
                 attachments,
                 reply_author,
                 reply_content,
+                reply_channel_id,
+                reply_message_id,
             ),
         )
         await self.conn.commit()
@@ -116,7 +139,8 @@ class Database:
         cursor = await self.conn.execute(
             """
             SELECT message_id, author_id, author_name, content,
-                   created_at, attachments, reply_author, reply_content
+                   created_at, attachments, reply_author, reply_content,
+                   reply_channel_id, reply_message_id
             FROM snipes WHERE channel_id = ?;
             """,
             (channel_id,),
@@ -138,14 +162,17 @@ class Database:
         attachments: str,
         reply_author: str | None,
         reply_content: str | None,
+        reply_channel_id: str | None,
+        reply_message_id: str | None,
     ):
         await self.conn.execute(
             """
             INSERT INTO edit_snipes (
                 channel_id, message_id, author_id, author_name,
                 before_content, after_content, created_at, edited_at,
-                attachments, reply_author, reply_content
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                attachments, reply_author, reply_content,
+                reply_channel_id, reply_message_id
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(channel_id) DO UPDATE SET
                 message_id=excluded.message_id,
                 author_id=excluded.author_id,
@@ -156,7 +183,9 @@ class Database:
                 edited_at=excluded.edited_at,
                 attachments=excluded.attachments,
                 reply_author=excluded.reply_author,
-                reply_content=excluded.reply_content;
+                reply_content=excluded.reply_content,
+                reply_channel_id=excluded.reply_channel_id,
+                reply_message_id=excluded.reply_message_id;
             """,
             (
                 channel_id,
@@ -170,6 +199,8 @@ class Database:
                 attachments,
                 reply_author,
                 reply_content,
+                reply_channel_id,
+                reply_message_id,
             ),
         )
         await self.conn.commit()
@@ -179,7 +210,8 @@ class Database:
             """
             SELECT message_id, author_id, author_name, before_content,
                    after_content, created_at, edited_at, attachments,
-                   reply_author, reply_content
+                   reply_author, reply_content, reply_channel_id,
+                   reply_message_id
             FROM edit_snipes WHERE channel_id = ?;
             """,
             (channel_id,),


### PR DESCRIPTION
## Summary
- show inline images in log/snipe/edit embeds
- add jump buttons for replies
- track reply message info in the database

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6867352b80548321a23c8c599e7ca464